### PR TITLE
fix xunit

### DIFF
--- a/XUnitTestProject/XUnitTestProject.csproj
+++ b/XUnitTestProject/XUnitTestProject.csproj
@@ -10,6 +10,7 @@
 
   <ItemGroup>
       <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
+      <PackageReference Include="NuGet.Frameworks" Version="6.4.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>


### PR DESCRIPTION
As suggested in https://github.com/dotnet/roslyn/issues/52954, adding a reference to `NuGet.Frameworks` resolves the issue.

